### PR TITLE
#28 NECP_CLIENT_ACTION_ADD_FLOW

### DIFF
--- a/NetworkInterceptor/Source/URLProtocol/NetworkRedirectUrlProtocol.swift
+++ b/NetworkInterceptor/Source/URLProtocol/NetworkRedirectUrlProtocol.swift
@@ -12,6 +12,11 @@ class NetworkRedirectUrlProtocol: URLProtocol {
 
     var session: URLSession?
     var sessionTask: URLSessionTask?
+    private static var sharedSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = nil
+        return URLSession(configuration: config)
+    }()
     
     open override class func canInit(with request: URLRequest) -> Bool {
         if let httpHeaders = request.allHTTPHeaderFields, let refiredValue = httpHeaders["Redirected"], refiredValue == "true" {
@@ -29,17 +34,14 @@ class NetworkRedirectUrlProtocol: URLProtocol {
     open override func startLoading() {
         
         guard var redirectedRequest = NetworkInterceptor.shared.redirectedRequest(urlRequest: self.request) else {
-            return
+            return 
         }
         #if DEBUG
             NSLog("Redirected Request CURL => \(redirectedRequest.cURL)")
         #endif
         redirectedRequest.addValue("true", forHTTPHeaderField: "Redirected")
         
-        let config = URLSessionConfiguration.default
-        config.protocolClasses = [type(of: self)]
-        
-        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        session = NetworkRedirectUrlProtocol.sharedSession
         sessionTask = session?.dataTask(with: redirectedRequest, completionHandler: { [weak self] (data, response, error) in
             guard let strongSelf = self else { return }
             


### PR DESCRIPTION
fixes #28 — Create a single shared URLSession instance and reuse it instead of creating a new one for each request.
Preventing excessive connection creation, reduces memory usage, and avoids NECP_CLIENT_ACTION_ADD_FLOW [12: Cannot allocate memory] errors.